### PR TITLE
Fix router reattach crash on process restart

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -73,9 +73,7 @@ async def register_registry():
 
 
 if __name__ == '__main__':
-    while True:
-        try:
-            asyncio.run(main())
-        except (KeyboardInterrupt, SystemExit):
-            logger.info("Bot stopped!")
-            exit(0)
+    try:
+        asyncio.run(main())
+    except (KeyboardInterrupt, SystemExit):
+        logger.info("Bot stopped!")


### PR DESCRIPTION
## Summary
- remove infinite restart loop around `asyncio.run(main())`
- avoid re-attaching routers to the same dispatcher instance in one process
- keep graceful shutdown handling for KeyboardInterrupt/SystemExit

## Verification
- `python3 -m compileall app/__main__.py`
